### PR TITLE
Allow user to set multiple authors per book

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,11 @@
 
 This project uses [Sanity](https://www.sanity.io/docs/getting-started) as the CMS and serves the content using their [GraphQl API](https://www.sanity.io/docs/graphql).
 
-To access the api add the project ID to your `.env.local` and `.env.test.local` files
+To access the api add the project ID & development dataset to your `.env.local` and `.env.test.local` files
 
-```bash
+```.env
 NEXT_PUBLIC_SANITY_PROJECT_ID=<your project ID>
+NEXT_PUBLIC_SANITY_DATASET=development
 ```
 
 Don't forget to update this ID within the sanity.json file either

--- a/__mocks__/fakeData.js
+++ b/__mocks__/fakeData.js
@@ -3,12 +3,14 @@ const fakeData = {
     {
       _id: 'f4e7685b-1119-411f-855b-6f77e4816f6b',
       title: 'The Eye of the World',
-      author: {
-        name: 'Robert Jordan',
-        slug: {
-          current: 'robert-jordan',
+      author: [
+        {
+          name: 'Robert Jordan',
+          slug: {
+            current: 'robert-jordan',
+          },
         },
-      },
+      ],
       slug: {
         current: 'the-eye-of-the-world',
       },
@@ -46,12 +48,14 @@ const fakeData = {
     {
       _id: 'eb00b46d-45ef-456c-91c6-14d367cbe611',
       title: 'The Great Hunt',
-      author: {
-        name: 'Robert Jordan',
-        slug: {
-          current: 'robert-jordan',
+      author: [
+        {
+          name: 'Robert Jordan',
+          slug: {
+            current: 'robert-jordan',
+          },
         },
-      },
+      ],
       slug: {
         current: 'the-great-hunt',
       },
@@ -103,12 +107,14 @@ const fakeData = {
     {
       _id: '5483de4a-44fb-4b1c-8f13-586b0aa0e91b',
       title: "'Salems Lot",
-      author: {
-        name: 'Stephen King',
-        slug: {
-          current: 'stephen-king',
+      author: [
+        {
+          name: 'Stephen King',
+          slug: {
+            current: 'stephen-king',
+          },
         },
-      },
+      ],
       slug: {
         current: 'salems-lot',
       },

--- a/__mocks__/fakeData_formatted.js
+++ b/__mocks__/fakeData_formatted.js
@@ -2,8 +2,14 @@ const fakeData_formatted = [
   {
     _id: '2f07baf9-756d-40c6-9722-9d1a74ec8749',
     title: 'This is Going to Hurt: Secret Diaries of a Junior Doctor',
-    author: 'Adam Kay',
-    authorSlug: 'adam-kay',
+    author: [
+      {
+        name: 'Adam Kay',
+        slug: {
+          current: 'adam-kay',
+        },
+      },
+    ],
     slug: {
       current: 'this-is-going-to-hurt',
     },
@@ -24,8 +30,14 @@ const fakeData_formatted = [
   {
     _id: 'c27b860c-51cd-4f2f-83f2-52fc72bf5c73',
     title: 'The Last Wish',
-    author: 'Andrzej Sapkowski',
-    authorSlug: 'andrzej-sapkowski',
+    author: [
+      {
+        name: 'Andrzej Sapkowski',
+        slug: {
+          current: 'andrzej-sapkowski',
+        },
+      },
+    ],
     slug: {
       current: 'the-last-wish',
     },
@@ -149,8 +161,14 @@ const fakeData_formatted = [
   {
     _id: '1f1b975e-7926-43f3-b116-09235eecf05b',
     title: 'Arcanium Unbounded',
-    author: 'Brandon Sanderson',
-    authorSlug: 'brandon-sanderson',
+    author: [
+      {
+        name: 'Brandon Sanderson',
+        slug: {
+          current: 'brandon-sanderson',
+        },
+      },
+    ],
     slug: {
       current: 'arcanium-unbounded',
     },
@@ -171,8 +189,14 @@ const fakeData_formatted = [
   {
     _id: 'efb4d371-1c33-4feb-841b-9a7c3cf8eb48',
     title: 'Elantris',
-    author: 'Brandon Sanderson',
-    authorSlug: 'brandon-sanderson',
+    author: [
+      {
+        name: 'Brandon Sanderson',
+        slug: {
+          current: 'brandon-sanderson',
+        },
+      },
+    ],
     slug: {
       current: 'elantris',
     },
@@ -193,8 +217,14 @@ const fakeData_formatted = [
   {
     _id: '9f40fb32-3160-4c33-8611-2d18d02bd55f',
     title: 'The Final Empire',
-    author: 'Brandon Sanderson',
-    authorSlug: 'brandon-sanderson',
+    author: [
+      {
+        name: 'Brandon Sanderson',
+        slug: {
+          current: 'brandon-sanderson',
+        },
+      },
+    ],
     slug: {
       current: 'the-final-empire',
     },

--- a/__mocks__/fakeData_single.js
+++ b/__mocks__/fakeData_single.js
@@ -2,9 +2,14 @@ const fakeData_single = {
   allBook: [
     {
       title: 'The Eye of the World',
-      author: {
-        name: 'Robert Jordan',
-      },
+      author: [
+        {
+          name: 'Robert Jordan',
+          slug: {
+            current: 'robert-jordan',
+          },
+        },
+      ],
       series: {
         name: 'The Wheel of Time',
       },

--- a/__tests__/Book.test.js
+++ b/__tests__/Book.test.js
@@ -1,0 +1,83 @@
+import { render, screen } from '@testing-library/react';
+import Book from '../src/pages/[book]';
+
+const book = {
+  title: 'The Eye of the World',
+  author: [
+    {
+      name: 'Robert Jordan',
+    },
+  ],
+  series: 'The Wheel of Time',
+  blurb: [
+    {
+      _key: '7dbedc86f6f4',
+      _type: 'block',
+      children: [
+        {
+          _key: 'adc9fcaa8f04',
+          _type: 'span',
+          marks: [],
+          text: 'When she arrives in a small village in the Two Rivers, Moiraine discovers three young men, each of whom might be the long-awaited and reviled Chosen One, the Dragon Reborn. But she is not the only stranger new to the village, nor the only one searching.\n\nIn a race against time and the agents of the Shadow, she must guide her charges through lands of myth and legend, toward allies both new and old, and into the footsteps of prophecy.\n\nThe Wheel of Time turns, and an epic adventure begins.',
+        },
+      ],
+      markDefs: [],
+      style: 'normal',
+    },
+  ],
+  cover: {
+    url: 'https://cdn.sanity.io/images/vvmrkra8/development/b6474707bb6845cdc5e2f0901067b76c57d2e8f5-1043x1600.webp',
+    altText: null,
+    metadata: {
+      lqip: 'data:image/jpeg;base64,/9j/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAAfABQDASIAAhEBAxEB/8QAGAAAAwEBAAAAAAAAAAAAAAAAAAUGBwj/xAAnEAACAQQBAgUFAAAAAAAAAAABAgMABAUREhMhBgcxUXEWMkGBsf/EABYBAQEBAAAAAAAAAAAAAAAAAAIDBP/EABoRAQADAQEBAAAAAAAAAAAAAAEAAhEDBEH/2gAMAwEAAhEDEQA/AM38lIsLj5bvI5NjK8cJPTPYVs3hDxLg/pvMZDBrHb5AR8pEY6JPp2rmvBWlzdY2V4CFi3xYFtEj3+KoI5bu0x4tYViCMhXYYb/ZrB287dXZqr0AwJVeNfM6zv8ALxvBZPL04EjdmOjyG9/2isYzKzW2QljY7PYk0VevCoBJvV2N8Zm7iG1jG4olA4Ltd8vmm0t7eSBXiREj1vtHsE/moqFg3SLsOKH7detVOOzEFphL2N3czTjiiqOye5qlh+EBaJ83czzXge46IcoOy+1FJptmVjy5d/U0U8h2f//Z',
+    },
+  },
+  readStatus: ['read'],
+  related: null,
+};
+
+test('renders the book page with a single author', () => {
+  render(
+    <Book
+      title={book.title}
+      author={book.author}
+      series={book.series}
+      blurb={book.blurb}
+      cover={book.cover}
+      readStatus={book.readStatus}
+      related={book.related}
+    />,
+  );
+
+  const img = screen.getByRole('img');
+  const h1 = screen.getByRole('heading', { level: 1 });
+  const series = screen.getByTestId('series');
+  const author = screen.getByTestId('author');
+  const blurb = screen.getByTestId('blurb');
+
+  expect(img).toBeInTheDocument();
+  expect(h1).toHaveTextContent(/the eye of the world/i);
+  expect(series).toHaveTextContent(/the wheel of time/i);
+  expect(author).toHaveTextContent(/robert jordan/i);
+  expect(blurb).toBeInTheDocument();
+});
+
+test('renders the book page with two authors', () => {
+  book.author = [{ name: 'Robert Jordan' }, { name: 'Brandon Sanderson' }];
+
+  render(
+    <Book
+      title={book.title}
+      author={book.author}
+      series={book.series}
+      blurb={book.blurb}
+      cover={book.cover}
+      readStatus={book.readStatus}
+      related={book.related}
+    />,
+  );
+
+  const author = screen.getByTestId('author');
+
+  expect(author).toHaveTextContent(/Robert Jordan, Brandon Sanderson/i);
+});

--- a/__tests__/queryBooks.test.js
+++ b/__tests__/queryBooks.test.js
@@ -10,7 +10,7 @@ import fakeData_formatted from '../__mocks__/fakeData_formatted';
 import fakeData_single from '../__mocks__/fakeData_single';
 import fakeData_series from '../__mocks__/fakeData_series';
 
-const queryUrl = `https://${process.env.NEXT_PUBLIC_SANITY_PROJECT_ID}.api.sanity.io/v1/graphql/production/default`;
+const queryUrl = `https://${process.env.NEXT_PUBLIC_SANITY_PROJECT_ID}.api.sanity.io/v1/graphql/${process.env.NEXT_PUBLIC_SANITY_DATASET}/default`;
 
 beforeEach(() => {
   fetch.resetMocks();

--- a/__tests__/queryBooks.test.js
+++ b/__tests__/queryBooks.test.js
@@ -56,8 +56,14 @@ it('successfully formats our data and builds the array', async () => {
   expect(formattedData[0]).toMatchObject({
     _id: 'f4e7685b-1119-411f-855b-6f77e4816f6b',
     title: 'The Eye of the World',
-    author: 'Robert Jordan',
-    authorSlug: 'robert-jordan',
+    author: [
+      {
+        name: 'Robert Jordan',
+        slug: {
+          current: 'robert-jordan',
+        },
+      },
+    ],
     slug: { current: 'the-eye-of-the-world' },
     series: 'The Wheel of Time',
     bookNumber: 1,

--- a/__tests__/sanityContent.test.js
+++ b/__tests__/sanityContent.test.js
@@ -1,7 +1,7 @@
 import getSanityContent from '../src/lib/sanity';
 import fakeData from '../__mocks__/fakeData';
 
-const queryUrl = `https://${process.env.NEXT_PUBLIC_SANITY_PROJECT_ID}.api.sanity.io/v1/graphql/production/default`;
+const queryUrl = `https://${process.env.NEXT_PUBLIC_SANITY_PROJECT_ID}.api.sanity.io/v1/graphql/${process.env.NEXT_PUBLIC_SANITY_DATASET}/default`;
 
 beforeEach(() => {
   fetch.resetMocks();

--- a/src/components/Bookshelf.js
+++ b/src/components/Bookshelf.js
@@ -28,14 +28,17 @@ const Bookshelf = ({ books }) => {
       // Filter results when both author and status are selected
       if (filteredValues.author !== 'all' && filteredValues.status !== 'all') {
         return (
-          filteredValues.author === book.authorSlug &&
-          filteredValues.status === book.readStatus[0].toLowerCase()
+          book.author.some(
+            (author) => author.slug.current === filteredValues.author,
+          ) && filteredValues.status === book.readStatus[0].toLowerCase()
         );
       }
 
       // Filter results when only author is selected
       if (filteredValues.author !== 'all') {
-        return filteredValues.author === book.authorSlug;
+        return book.author.some(
+          (author) => author.slug.current === filteredValues.author,
+        );
       }
 
       // Filter results when only status is selected

--- a/src/components/Filter.js
+++ b/src/components/Filter.js
@@ -2,8 +2,13 @@ import Select from './Form/Select';
 import Radio from './Form/Radio';
 
 const Filter = ({ books, filteredValues, handleChange }) => {
-  const authors = books.map((book) => book.author);
-  const uniqAuthors = [...new Set(authors)];
+  const authors = books.map((book) => {
+    // Pull out the name from the author object
+    const author = book.author.map((author) => author.name);
+
+    return author;
+  });
+  const uniqAuthors = [...new Set(authors.flat())];
   const readStatuses = ['Read', 'Reading', 'Not read'];
 
   return (

--- a/src/lib/queryBooks.js
+++ b/src/lib/queryBooks.js
@@ -152,11 +152,13 @@ const buildBooksArray = async (allBooks) => {
         // Get books by series and pass them into each response
         const querySeries = await queryBooksBySeries(series);
         const relatedBooks = querySeries ? querySeries.allBook : null;
+        // Ensuer author is always an array
+        const author = Array.isArray(book.author) ? book.author : [book.author];
 
         return {
           _id: book._id,
           title: book.title,
-          author: book.author,
+          author,
           slug: book.slug,
           series,
           bookNumber: book.bookNumber,

--- a/src/lib/queryBooks.js
+++ b/src/lib/queryBooks.js
@@ -173,9 +173,12 @@ const buildBooksArray = async (allBooks) => {
     // Otherwise move it down
     // Then sort by title
 
-    const compareAuthor = a.author[0].name
+    const authorA = a.author[0]?.name ? a.author[0].name : a.author;
+    const authorB = b.author[0]?.name ? b.author[0].name : b.author;
+
+    const compareAuthor = authorA
       .toLowerCase()
-      .localeCompare(b.author[0].name.toLowerCase());
+      .localeCompare(authorB.toLowerCase());
     const compareTitle = a.title
       .toLowerCase()
       .localeCompare(b.title.toLowerCase());

--- a/src/lib/queryBooks.js
+++ b/src/lib/queryBooks.js
@@ -156,8 +156,7 @@ const buildBooksArray = async (allBooks) => {
         return {
           _id: book._id,
           title: book.title,
-          author: book.author.name,
-          authorSlug: book.author.slug.current, //TODO: Move this into the author property
+          author: book.author,
           slug: book.slug,
           series,
           bookNumber: book.bookNumber,
@@ -174,9 +173,9 @@ const buildBooksArray = async (allBooks) => {
     // Otherwise move it down
     // Then sort by title
 
-    const compareAuthor = a.author
+    const compareAuthor = a.author[0].name
       .toLowerCase()
-      .localeCompare(b.author.toLowerCase());
+      .localeCompare(b.author[0].name.toLowerCase());
     const compareTitle = a.title
       .toLowerCase()
       .localeCompare(b.title.toLowerCase());
@@ -197,9 +196,13 @@ const buildBooksArray = async (allBooks) => {
 const sortBooks = (books, sortBy) => {
   // Sort sortBy value alphabetically
   books.sort((a, b) => {
-    const compareSortByVal = a[sortBy]
+    // Check whether we're sorting against and object (namely the author) or just a string
+    const sortByA = a[sortBy][0]?.name ? a[sortBy][0].name : a[sortBy];
+    const sortByB = b[sortBy][0]?.name ? b[sortBy][0].name : b[sortBy];
+
+    const compareSortByVal = sortByA
       .toLowerCase()
-      .localeCompare(b[sortBy].toLowerCase());
+      .localeCompare(sortByB.toLowerCase());
     const compareTitle = a.title
       .toLowerCase()
       .localeCompare(b.title.toLowerCase());

--- a/src/lib/sanity.js
+++ b/src/lib/sanity.js
@@ -1,6 +1,6 @@
 const getSanityContent = async ({ query, variables = {} }) => {
   const { data } = await fetch(
-    `https://${process.env.NEXT_PUBLIC_SANITY_PROJECT_ID}.api.sanity.io/v1/graphql/production/default`,
+    `https://${process.env.NEXT_PUBLIC_SANITY_PROJECT_ID}.api.sanity.io/v1/graphql/${process.env.NEXT_PUBLIC_SANITY_DATASET}/default`,
     {
       method: 'POST',
       headers: {

--- a/src/pages/[book].js
+++ b/src/pages/[book].js
@@ -16,6 +16,8 @@ export default function Book({
   readStatus,
   related,
 }) {
+  const authorNames = author.map(({ name }) => name).join(', ');
+
   return (
     <>
       <Head>
@@ -60,22 +62,26 @@ export default function Book({
             <p
               className="fs-3 fw-600 lh-1"
               style={{ '--stack-space': 'var(--space-s)' }}
+              data-testid="series"
             >
               {series}
             </p>
           ) : null}
-          {author ? (
-            <p
-              className="fs-2 fw-600 lh-1"
-              style={{ '--stack-space': 'var(--space-2xs)' }}
-            >
-              {author}
-            </p>
-          ) : null}
+          <p
+            className="fs-2 fw-600 lh-1"
+            style={{ '--stack-space': 'var(--space-2xs)' }}
+            data-testid="author"
+          >
+            {authorNames}
+          </p>
 
           {readStatus ? <ReadStatus status={readStatus} /> : null}
 
-          <div className="stack" style={{ marginTop: 'var(--space-l)' }}>
+          <div
+            className="stack"
+            style={{ marginTop: 'var(--space-l)' }}
+            data-testid="blurb"
+          >
             {blurb ? <PortableText value={blurb} /> : null}
           </div>
         </div>
@@ -96,7 +102,7 @@ export async function getStaticProps({ params }) {
   const book = await querySingleBook(params.book);
 
   const { title, blurbRaw: blurb, readStatus } = book;
-  const author = book.author ? book.author.name : null;
+  const author = Array.isArray(book.author) ? book.author : [book.author];
   const series = book.series ? book.series.name : null;
   const cover = book.cover ? book.cover.asset : null;
 

--- a/studio/sanity.json
+++ b/studio/sanity.json
@@ -18,6 +18,9 @@
   ],
   "env": {
     "development": {
+      "api": {
+        "dataset": "development"
+      },
       "plugins": ["@sanity/vision"]
     }
   },

--- a/studio/schemas/documents/book.js
+++ b/studio/schemas/documents/book.js
@@ -40,8 +40,14 @@ export default {
     {
       name: 'author',
       title: 'Author',
-      type: 'reference',
-      to: [{ type: 'author' }],
+      type: 'array',
+      of: [
+        {
+          type: 'reference',
+          title: 'Author',
+          to: [{ type: 'author' }],
+        },
+      ],
     },
     {
       name: 'readStatus',


### PR DESCRIPTION
As an alternative to just fixing 

- #19 

I've updated the book document in our Sanity project so that the reference to the author is an array. This means that we can set multiple authors per book rather than having to create a new "X & Y" author each time.

This is a breaking change to the filter however as the returned value is now an object that can contain multiple items, as opposed to the previous one.

I've accounted for this by updating the sort functions in the bookshelf component to use the `.some()` array method to check each object and then I've updated the sort functions within the queryBooks.js file to check for the name property and if it's not there fallback to just sorting by the string.